### PR TITLE
Fix section numbering in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,6 @@ Both the code repository and the model weights are released under the [Modified 
 
 ---
 
-## 9. Contact Us
+## 8. Contact Us
 
 If you have any questions, please reach out at [support@moonshot.cn](mailto:support@moonshot.cn).


### PR DESCRIPTION
The section numbering in the readme jumps from 7 to 9.

Demonstration of issue:
<img width="950" height="508" alt="image" src="https://github.com/user-attachments/assets/f9bd7af9-eb55-4f91-8f67-9757fbaaa95f" />

This has a trivial fix: the "Contact Us" section is re-numbered to 8.